### PR TITLE
Add account approval and reset password support

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -1,4 +1,6 @@
-from flask import Blueprint, render_template, request, redirect, url_for, flash
+"""Authentication routes for Flask application."""
+
+from flask import Blueprint, render_template, request, redirect, url_for, flash, session
 from flask_login import login_user, logout_user
 from services import auth as auth_service
 
@@ -10,34 +12,63 @@ def login():
     if request.method == "POST":
         email = request.form.get("email")
         password = request.form.get("password")
-        user = auth_service.authenticate(email, password)
+        user, error = auth_service.authenticate(email, password)
         if user:
             login_user(user)
-            return redirect(url_for("quote.quote"))
-        flash("Invalid credentials")
+            session["role"] = getattr(user, "role", "user")
+            session["name"] = getattr(user, "name", "")
+            session["email"] = getattr(user, "email", "")
+            target = "admin.dashboard" if session["role"] == "admin" else "quote.quote"
+            return redirect(url_for(target))
+        flash(error)
     return render_template("login.html")
 
 
 @auth_bp.route("/register", methods=["GET", "POST"])
 def register():
     if request.method == "POST":
-        data = {
-            "name": request.form.get("name"),
-            "email": request.form.get("email"),
-            "phone": request.form.get("phone"),
-            "business_name": request.form.get("business_name"),
-            "business_phone": request.form.get("business_phone"),
-            "password": request.form.get("password"),
-        }
-        error = auth_service.register_user(data)
-        if not error:
-            flash("Registration successful. Please log in.")
-            return redirect(url_for("auth.login"))
-        flash(error)
+        password = request.form.get("password")
+        confirm = request.form.get("confirm_password")
+        if password != confirm:
+            flash("Passwords do not match")
+        else:
+            data = {
+                "name": request.form.get("name"),
+                "email": request.form.get("email"),
+                "phone": request.form.get("phone"),
+                "business_name": request.form.get("business_name"),
+                "business_phone": request.form.get("business_phone"),
+                "password": password,
+            }
+            error = auth_service.register_user(data)
+            if not error:
+                flash("Registration successful. Please log in.")
+                return redirect(url_for("auth.login"))
+            flash(error)
     return render_template("register.html")
+
+
+@auth_bp.route("/reset-password", methods=["GET", "POST"])
+def reset_password():
+    if request.method == "POST":
+        email = request.form.get("email")
+        new_password = request.form.get("new_password")
+        confirm = request.form.get("confirm_password")
+        if new_password != confirm:
+            flash("Passwords do not match")
+        else:
+            error = auth_service.reset_password(email, new_password)
+            if not error:
+                flash("Password updated. Please log in.")
+                return redirect(url_for("auth.login"))
+            flash(error)
+    return render_template("reset_password.html")
 
 
 @auth_bp.route("/logout")
 def logout():
     logout_user()
+    session.pop("role", None)
+    session.pop("name", None)
+    session.pop("email", None)
     return redirect(url_for("auth.login"))

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,4 +12,6 @@
   <label>Password <input type="password" name="password"></label><br>
   <button type="submit">Login</button>
 </form>
-<a href="{{ url_for('auth.register') }}">Register</a>
+<a href="{{ url_for('auth.register') }}">Register</a> |
+<a href="{{ url_for('auth.reset_password') }}">Forgot password?</a>
+

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<title>Register</title>
+<title>Reset Password</title>
 {% with messages = get_flashed_messages() %}
   {% if messages %}
     <ul>
@@ -8,14 +8,10 @@
   {% endif %}
 {% endwith %}
 <form method="post">
-  <label>Name <input type="text" name="name"></label><br>
   <label>Email <input type="email" name="email"></label><br>
-  <label>Phone <input type="text" name="phone"></label><br>
-  <label>Business Name <input type="text" name="business_name"></label><br>
-  <label>Business Phone <input type="text" name="business_phone"></label><br>
-  <label>Password <input type="password" name="password"></label><br>
+  <label>New Password <input type="password" name="new_password"></label><br>
   <label>Confirm Password <input type="password" name="confirm_password"></label><br>
-  <button type="submit">Register</button>
+  <button type="submit">Reset Password</button>
 </form>
 <a href="{{ url_for('auth.login') }}">Login</a>
 


### PR DESCRIPTION
## Summary
- enforce password complexity and return helpful auth errors
- track user role in session and redirect admins to dashboard
- add password reset route and templates with confirm-password fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4b1f819a083338456408caeca4656