### PR TITLE
Enhance quote workflow with dimensional weight and accessorials

### DIFF
--- a/services/quote.py
+++ b/services/quote.py
@@ -5,6 +5,50 @@ from quote.logic_hotshot import calculate_hotshot_quote
 from quote.logic_air import calculate_air_quote
 
 BOOK_PATH = "HotShot Quote.xlsx"
+BOOK_URL = "https://freightservices.ts2000.net/login?returnUrl=%2FLogin%2F"
+
+
+def _first_numeric_in_column(series: pd.Series) -> float:
+    """Return the first numeric value in a column; handle $, commas, and %."""
+    for val in series.tolist():
+        s = str(val).strip()
+        if not s:
+            continue
+        if "multiply" in s.lower():
+            # Skip instructional text like "multiply total by 1.25"
+            continue
+        s = s.replace("$", "").replace(",", "")
+        if s.endswith("%"):
+            # Percentage-based accessorials handled separately (e.g., Guarantee)
+            continue
+        try:
+            return float(s)
+        except Exception:
+            continue
+    return 0.0
+
+
+def _headers_as_accessorials(df: pd.DataFrame) -> list[str]:
+    """Use table headers as accessorial labels; skip blank/unnamed columns."""
+    headers = []
+    for c in df.columns:
+        label = str(c).strip()
+        if not label or label.lower().startswith("unnamed"):
+            continue
+        headers.append(label)
+    return headers
+
+
+def get_accessorial_options(quote_type: str) -> list[str]:
+    """Return list of accessorial names from workbook headers."""
+    wb = _load_workbook()
+    df = wb.get("Accessorials")
+    if df is None:
+        return []
+    options = _headers_as_accessorials(df)
+    if quote_type == "Hotshot":
+        options = [a for a in options if "guarantee" not in a.lower()]
+    return options
 
 
 def _load_workbook():
@@ -12,15 +56,52 @@ def _load_workbook():
     return normalize_workbook(wb)
 
 
-def create_quote(user_id, user_email, quote_type, origin, destination, weight,
-                  accessorial_total=0.0):
+def create_quote(
+    user_id,
+    user_email,
+    quote_type,
+    origin,
+    destination,
+    weight,
+    accessorial_total=0.0,
+    pieces=1,
+    length=0.0,
+    width=0.0,
+    height=0.0,
+    accessorials=None,
+):
     """Generate a quote and persist to the database."""
     workbook = _load_workbook()
+
+    actual_weight = weight
+    dim_weight = 0.0
+    if all(v > 0 for v in [length, width, height]):
+        dim_weight = (length * width * height / 166) * pieces
+    billable_weight = max(actual_weight, dim_weight)
+    weight_method = "Dimensional" if billable_weight == dim_weight and dim_weight > 0 else "Actual"
+
+    subtotal = accessorial_total
+    guarantee_selected = False
+    if accessorials:
+        df = workbook.get("Accessorials")
+        for acc in accessorials:
+            if "guarantee" in acc.lower():
+                guarantee_selected = True
+                continue
+            if df is not None and acc in df.columns:
+                subtotal += _first_numeric_in_column(df[acc])
+
     if quote_type == "Air":
-        result = calculate_air_quote(origin, destination, weight, accessorial_total, workbook)
+        result = calculate_air_quote(origin, destination, billable_weight, subtotal, workbook)
     else:
-        result = calculate_hotshot_quote(origin, destination, weight, accessorial_total, workbook["Hotshot Rates"])
+        result = calculate_hotshot_quote(
+            origin, destination, billable_weight, subtotal, workbook["Hotshot Rates"]
+        )
+
     quote_total = result["quote_total"]
+    if quote_type == "Air" and guarantee_selected:
+        quote_total *= 1.25
+
     db = Session()
     q = Quote(
         user_id=user_id,
@@ -28,10 +109,17 @@ def create_quote(user_id, user_email, quote_type, origin, destination, weight,
         quote_type=quote_type,
         origin=origin,
         destination=destination,
-        weight=weight,
-        weight_method="Actual",
+        weight=billable_weight,
+        weight_method=weight_method,
+        actual_weight=actual_weight,
+        dim_weight=dim_weight,
+        pieces=pieces,
+        length=length,
+        width=width,
+        height=height,
         zone=str(result.get("zone", "")),
         total=quote_total,
+        quote_metadata=", ".join(accessorials or []),
     )
     db.add(q)
     db.commit()

--- a/templates/quote.html
+++ b/templates/quote.html
@@ -10,18 +10,37 @@
 <form method="post">
   <label>Type
     <select name="quote_type">
-      <option value="Hotshot">Hotshot</option>
-      <option value="Air">Air</option>
+      <option value="Hotshot" {% if request.form.get('quote_type', 'Hotshot') == 'Hotshot' %}selected{% endif %}>Hotshot</option>
+      <option value="Air" {% if request.form.get('quote_type') == 'Air' %}selected{% endif %}>Air</option>
     </select>
   </label><br>
-  <label>Origin Zip <input type="text" name="origin"></label><br>
-  <label>Destination Zip <input type="text" name="destination"></label><br>
-  <label>Weight (lbs) <input type="number" step="0.01" name="weight"></label><br>
+  <label>Origin Zip <input type="text" name="origin" value="{{ request.form.origin }}"></label><br>
+  <label>Destination Zip <input type="text" name="destination" value="{{ request.form.destination }}"></label><br>
+  <label>Actual Weight (lbs) <input type="number" step="0.01" name="weight" value="{{ request.form.weight }}"></label><br>
+  <label>Pieces <input type="number" name="pieces" value="{{ request.form.get('pieces', 1) }}"></label><br>
+  <label>Length (in) <input type="number" step="0.01" name="length" value="{{ request.form.length }}"></label><br>
+  <label>Width (in) <input type="number" step="0.01" name="width" value="{{ request.form.width }}"></label><br>
+  <label>Height (in) <input type="number" step="0.01" name="height" value="{{ request.form.height }}"></label><br>
+  {% if accessorial_options %}
+  <fieldset>
+    <legend>Accessorials</legend>
+    {% for acc in accessorial_options %}
+      <label><input type="checkbox" name="accessorials" value="{{ acc }}" {% if acc in request.form.getlist('accessorials') %}checked{% endif %}> {{ acc }}</label><br>
+    {% endfor %}
+  </fieldset>
+  {% endif %}
   <button type="submit">Generate Quote</button>
 </form>
 {% if quote %}
 <h2>Last Quote</h2>
-<p>ID: {{ quote.quote_id }} | Total: ${{ '%.2f'|format(quote.total) }}</p>
-<a href="{{ url_for('quote.email_request', quote_id=quote.quote_id) }}">Email Request</a>
+<div style="font-size:1.2em;line-height:1.4;">
+  Quote Total: ${{ '%.2f'|format(quote.total) }}<br>
+  Origin: {{ quote.origin }} | Destination: {{ quote.destination }}<br>
+  Type: {{ quote.quote_type }} | Weight: {{ '%.2f'|format(quote.weight) }} lbs
+</div>
+<p>
+  <a href="{{ url_for('quote.email_request', quote_id=quote.quote_id) }}">Email Request</a> |
+  <a href="{{ book_url }}" target="_blank" rel="noopener">Book Quote</a>
+</p>
 {% endif %}
 <a href="{{ url_for('auth.logout') }}">Logout</a>


### PR DESCRIPTION
## Summary
- add helper utilities to compute dimensional weight and accessorial totals
- expand quote service and route to handle package dimensions, pieces and accessorial selections
- show last quote summary with links to book or request via email

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4b1fcaa4c833381f80fd1ba9397a4