### PR TITLE
Add detailed email request form with accessorial pricing

### DIFF
--- a/routes/quote.py
+++ b/routes/quote.py
@@ -42,4 +42,5 @@ def email_request(quote_id):
         quote_service.create_email_request(quote_id, request.form)
         flash("Request submitted")
         return redirect(url_for("quote.quote"))
-    return render_template("email_request.html", quote=quote)
+    context = quote_service.build_email_context(quote)
+    return render_template("email_request.html", quote=quote, **context)

--- a/services/quote.py
+++ b/services/quote.py
@@ -3,13 +3,102 @@ from db import Session, Quote, EmailQuoteRequest
 from quote.utils import normalize_workbook
 from quote.logic_hotshot import calculate_hotshot_quote
 from quote.logic_air import calculate_air_quote
+from config import Config
 
-BOOK_PATH = "HotShot Quote.xlsx"
+
+BOOK_PATH = Config.WORKBOOK_PATH
+ADMIN_FEE = 15.00
 
 
 def _load_workbook():
     wb = pd.read_excel(BOOK_PATH, sheet_name=None)
     return normalize_workbook(wb)
+
+
+def _first_numeric(series: pd.Series) -> float:
+    """Return the first numeric-looking value in a column."""
+    for val in series.tolist():
+        s = str(val).strip()
+        if not s:
+            continue
+        if "multiply" in s.lower():
+            continue
+        s = s.replace("$", "").replace(",", "")
+        if s.endswith("%"):
+            continue
+        try:
+            return float(s)
+        except Exception:
+            continue
+    return 0.0
+
+
+def accessorial_prices(selected_names):
+    """Return [(name, price), ...] and subtotal for accessorials."""
+    names = [n for n in (selected_names or []) if "guarantee" not in str(n).lower()]
+    try:
+        wb = _load_workbook()
+        df = wb["Accessorials"]
+    except Exception:
+        return [(name, 0.0) for name in names], 0.0
+
+    rows, subtotal = [], 0.0
+    for name in names:
+        price = _first_numeric(df[name]) if name in df.columns else 0.0
+        price = float(price or 0.0)
+        rows.append((name, price))
+        subtotal += price
+    return rows, round(subtotal, 2)
+
+
+def build_email_context(quote: Quote):
+    """Assemble accessorial pricing and totals for the email request UI."""
+    selected_accessorials = []
+    if quote.quote_metadata:
+        selected_accessorials = [
+            s.strip() for s in str(quote.quote_metadata).split(",") if s and s.strip()
+        ]
+
+    acc_rows, acc_subtotal = accessorial_prices(selected_accessorials)
+    guarantee_selected = any("guarantee" in s.lower() for s in selected_accessorials)
+
+    guarantee_amount = 0.0
+    if guarantee_selected and str(quote.quote_type).lower() == "air":
+        pre_air_total = None
+        try:
+            wb = _load_workbook()
+            pre = calculate_air_quote(
+                origin=quote.origin,
+                destination=quote.destination,
+                weight=float(quote.weight or 0.0),
+                accessorial_total=float(acc_subtotal or 0.0),
+                workbook=wb,
+            )
+            pre_air_total = float(pre.get("quote_total", 0.0) or 0.0)
+        except Exception:
+            pre_air_total = None
+
+        if pre_air_total is not None and pre_air_total > 0:
+            guarantee_amount = round(pre_air_total * 0.25, 2)
+        else:
+            base_total = float(quote.total or 0.0)
+            guarantee_amount = round(base_total * 0.20, 2) if base_total > 0 else 0.0
+
+    acc_plus_guarantee_subtotal = round(float(acc_subtotal or 0.0) + float(guarantee_amount or 0.0), 2)
+    base_total = float(quote.total or 0.0)
+    email_total = base_total + ADMIN_FEE
+
+    return {
+        "selected_accessorials": selected_accessorials,
+        "acc_rows": acc_rows,
+        "acc_subtotal": acc_subtotal,
+        "guarantee_selected": guarantee_selected,
+        "guarantee_amount": guarantee_amount,
+        "acc_plus_guarantee_subtotal": acc_plus_guarantee_subtotal,
+        "base_total": base_total,
+        "email_total": email_total,
+        "admin_fee": ADMIN_FEE,
+    }
 
 
 def create_quote(user_id, user_email, quote_type, origin, destination, weight,

--- a/templates/email_request.html
+++ b/templates/email_request.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<title>Email Request</title>
+<title>Email Quote Request</title>
 {% with messages = get_flashed_messages() %}
   {% if messages %}
     <ul>
@@ -7,18 +7,47 @@
     </ul>
   {% endif %}
 {% endwith %}
-<h2>Quote ID: {{ quote.quote_id }}</h2>
+
+<h2>Email Quote Request (${{ '%.2f'|format(admin_fee) }} Admin Fee)</h2>
+<p><strong>Quote ID:</strong> {{ quote.quote_id }}</p>
+<p><strong>Origin:</strong> {{ quote.origin }} &nbsp; <strong>Destination:</strong> {{ quote.destination }} &nbsp; <strong>Weight:</strong> {{ quote.weight }}</p>
+
+{% if acc_rows %}
+<h3>Accessorials</h3>
+<table border="1" cellpadding="4" cellspacing="0">
+  <tr><th>Name</th><th>Price</th></tr>
+  {% for name, price in acc_rows %}
+    <tr><td>{{ name }}</td><td>${{ '%.2f'|format(price) }}</td></tr>
+  {% endfor %}
+  <tr><td><strong>Subtotal:</strong></td><td>${{ '%.2f'|format(acc_subtotal) }}</td></tr>
+  {% if guarantee_selected %}
+    <tr><td>Guarantee (25%)</td><td>${{ '%.2f'|format(guarantee_amount) }}</td></tr>
+    <tr><td><strong>Accessorials + Guarantee Subtotal:</strong></td><td>${{ '%.2f'|format(acc_plus_guarantee_subtotal) }}</td></tr>
+  {% endif %}
+</table>
+{% endif %}
+
+<p>Email processing adds a ${{ '%.2f'|format(admin_fee) }} admin fee. The 'Book Quote' button does not include this fee.</p>
+<p><strong>Quote Total:</strong> ${{ '%.2f'|format(email_total) }} (includes admin fee)</p>
+
 <form method="post">
-  <label>Shipper Name <input type="text" name="shipper_name"></label><br>
-  <label>Shipper Address <input type="text" name="shipper_address"></label><br>
-  <label>Shipper Contact <input type="text" name="shipper_contact"></label><br>
-  <label>Shipper Phone <input type="text" name="shipper_phone"></label><br>
-  <label>Consignee Name <input type="text" name="consignee_name"></label><br>
-  <label>Consignee Address <input type="text" name="consignee_address"></label><br>
-  <label>Consignee Contact <input type="text" name="consignee_contact"></label><br>
-  <label>Consignee Phone <input type="text" name="consignee_phone"></label><br>
-  <label>Total Weight <input type="number" step="0.01" name="total_weight"></label><br>
-  <label>Special Instructions <textarea name="special_instructions"></textarea></label><br>
+  <fieldset>
+    <legend>Shipper Information</legend>
+    <label>Name <input type="text" name="shipper_name"></label><br>
+    <label>Address <input type="text" name="shipper_address" value="{{ quote.origin }}"></label><br>
+    <label>Contact <input type="text" name="shipper_contact"></label><br>
+    <label>Phone <input type="text" name="shipper_phone"></label><br>
+  </fieldset>
+  <fieldset>
+    <legend>Consignee Information</legend>
+    <label>Name <input type="text" name="consignee_name"></label><br>
+    <label>Address <input type="text" name="consignee_address" value="{{ quote.destination }}"></label><br>
+    <label>Contact <input type="text" name="consignee_contact"></label><br>
+    <label>Phone <input type="text" name="consignee_phone"></label><br>
+  </fieldset>
+  <label>Total Weight <input type="number" step="0.01" name="total_weight" value="{{ quote.weight }}"></label><br>
+  <label>Special Instructions <textarea name="special_instructions">{{ selected_accessorials|join(', ') }}</textarea></label><br>
   <button type="submit">Submit</button>
 </form>
+
 <a href="{{ url_for('quote.quote') }}">Back to Quote</a>


### PR DESCRIPTION
## Summary
- add service helpers to price accessorials, recompute air guarantee, and build email form context
- render detailed email request form with totals, admin fee, and shipper/consignee fields
- wire quote route to use new context and persist EmailQuoteRequest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4b1fd56b883339d4984fd0e9d7aec