### PR TITLE
Update route tests for quotes blueprint

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,6 +7,8 @@ class Config:
         os.getenv("DATABASE_URL") or  # e.g. mysql+pymysql://user:pass@host/db
         "sqlite:///app.db"
     )
+    # Legacy configuration expected by old modules/tests
+    DATABASE_URL = SQLALCHEMY_DATABASE_URI
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     WORKBOOK_PATH = os.getenv("WORKBOOK_PATH", "HotShot Quote.xlsx")
     GOOGLE_MAPS_API_KEY = os.getenv("GOOGLE_MAPS_API_KEY", "")


### PR DESCRIPTION
## Summary
- Adjust route tests to target the `/quotes/new` endpoint and use the new SQLAlchemy models
- Add legacy `DATABASE_URL` setting to Config for compatibility with existing modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4f39b663483339bcf1a5ff2c443c9