### PR TITLE
Add password confirmation and complexity checks

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -2,6 +2,7 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash
 from flask_login import login_user, logout_user, login_required, current_user
 from .models import db, User
+from services.auth import is_valid_password
 
 auth_bp = Blueprint("auth", __name__, template_folder="templates")
 
@@ -23,9 +24,18 @@ def register():
         email = request.form.get("email", "").strip().lower()
         name = request.form.get("name", "").strip()
         password = request.form.get("password", "")
+        confirm_password = request.form.get("confirm_password", "")
 
-        if not email or not password:
-            flash("Email and password are required.", "warning")
+        if not email or not password or not confirm_password:
+            flash("Email, password, and confirmation are required.", "warning")
+            return redirect(url_for("auth.register"))
+
+        if password != confirm_password:
+            flash("Passwords do not match.", "warning")
+            return redirect(url_for("auth.register"))
+
+        if not is_valid_password(password):
+            flash("Password does not meet complexity requirements.", "warning")
             return redirect(url_for("auth.register"))
 
         if User.query.filter_by(email=email).first():


### PR DESCRIPTION
## Summary
- enforce password confirmation and complexity checks during user registration
- flash clear error messages when validation fails

## Testing
- `pytest -q` *(fails: AttributeError: type object 'Config' has no attribute 'DATABASE_URL')*

------
https://chatgpt.com/codex/tasks/task_b_68a4f3a7ba3883339c3efb09abc6b760