### PR TITLE
Cache workbook and handle load errors

### DIFF
--- a/services/quote.py
+++ b/services/quote.py
@@ -51,9 +51,19 @@ def get_accessorial_options(quote_type: str) -> list[str]:
     return options
 
 
+_WORKBOOK_CACHE = None
+
+
 def _load_workbook():
-    wb = pd.read_excel(BOOK_PATH, sheet_name=None)
-    return normalize_workbook(wb)
+    global _WORKBOOK_CACHE
+    if _WORKBOOK_CACHE is not None:
+        return _WORKBOOK_CACHE
+    try:
+        wb = pd.read_excel(BOOK_PATH, sheet_name=None)
+    except Exception as e:
+        raise RuntimeError(f"Failed to load workbook '{BOOK_PATH}': {e}") from e
+    _WORKBOOK_CACHE = normalize_workbook(wb)
+    return _WORKBOOK_CACHE
 
 
 def create_quote(

--- a/tests/test_services_load_workbook.py
+++ b/tests/test_services_load_workbook.py
@@ -1,0 +1,26 @@
+import pandas as pd
+import pytest
+
+from services import quote as quote_service
+
+
+def test_load_workbook_missing(monkeypatch):
+    monkeypatch.setattr(quote_service, "_WORKBOOK_CACHE", None)
+
+    def fake_read_excel(*args, **kwargs):
+        raise FileNotFoundError("missing")
+
+    monkeypatch.setattr(pd, "read_excel", fake_read_excel)
+    with pytest.raises(RuntimeError, match="Failed to load workbook"):
+        quote_service._load_workbook()
+
+
+def test_load_workbook_corrupted(monkeypatch):
+    monkeypatch.setattr(quote_service, "_WORKBOOK_CACHE", None)
+
+    def fake_read_excel(*args, **kwargs):
+        raise ValueError("corrupted")
+
+    monkeypatch.setattr(pd, "read_excel", fake_read_excel)
+    with pytest.raises(RuntimeError, match="Failed to load workbook"):
+        quote_service._load_workbook()


### PR DESCRIPTION
## Summary
- cache normalized workbook in-memory to avoid repeated reads
- raise clear error when workbook is missing or unreadable
- test missing and corrupted workbook load scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a4fd67cd0c8333a3268afe4719d55b