### PR TITLE
Add CSRF token and email field to reset password form

### DIFF
--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -8,6 +8,8 @@
   {% endif %}
 {% endwith %}
 <form method="post">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <label>Email <input type="email" name="email"></label><br>
   <label>New Password <input type="password" name="new_password"></label><br>
   <label>Confirm Password <input type="password" name="confirm_password"></label><br>
   <button type="submit">Reset Password</button>


### PR DESCRIPTION
## Summary
- include hidden CSRF token field in password reset form
- restore email input alongside new/confirm password fields

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a6059fe8ec833394314f0c6f85b29d