### PR TITLE
Load admin credentials from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Example environment configuration
+
+# Admin user credentials for init_db.py seeding
+ADMIN_EMAIL=
+ADMIN_PASSWORD=
+
+# API key for Google Maps
+GOOGLE_MAPS_API_KEY=
+
+# Flask secret
+SECRET_KEY=dev-secret-key
+
+# Path to rate workbook
+WORKBOOK_PATH=HotShot Quote.xlsx
+
+# Database configuration
+# DATABASE_URL=mysql+pymysql://user:password@host:3306/quote_tool

--- a/README.md
+++ b/README.md
@@ -80,11 +80,15 @@ This exposes `POST /api/quote` for generating quotes and
 
 ## 🔧 Admin Access
 
-A default admin account is seeded on first run:
+To seed an initial administrator, provide credentials through environment
+variables before running `init_db.py`:
 
-- **Email:** `admin@example.com`
-- **Password:** `SuperSecurePass!123`
-  *(Change in `init_db.py` if needed)*
+```
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=strong-password
+```
+
+If these variables are absent, the seeding step is skipped.
 
 ---
 

--- a/init_db.py
+++ b/init_db.py
@@ -62,22 +62,27 @@ else:
     print("ℹ️ Tables already exist. Skipping creation.")
 
 # === Seed Default Admin ===
-default_admin_email = "admin@example.com"
-existing_admin = session.query(User).filter_by(email=default_admin_email).first()
+admin_email = os.getenv("ADMIN_EMAIL")
+admin_password = os.getenv("ADMIN_PASSWORD")
 
-if not existing_admin:
-    admin_user = User(
-        name="Admin",
-        email=default_admin_email,
-        phone="555-0000",
-        business_name="FSI",
-        business_phone="555-1111",
-        password_hash=generate_password_hash("SuperSecurePass!123"),
-        role="admin",
-        is_approved=True,
-    )
-    session.add(admin_user)
-    session.commit()
-    print("✅ Default admin user created.")
+if admin_email and admin_password:
+    existing_admin = session.query(User).filter_by(email=admin_email).first()
+
+    if not existing_admin:
+        admin_user = User(
+            name="Admin",
+            email=admin_email,
+            phone="555-0000",
+            business_name="FSI",
+            business_phone="555-1111",
+            password_hash=generate_password_hash(admin_password),
+            role="admin",
+            is_approved=True,
+        )
+        session.add(admin_user)
+        session.commit()
+        print("✅ Default admin user created.")
+    else:
+        print("ℹ️ Admin user already exists.")
 else:
-    print("ℹ️ Admin user already exists.")
+    print("ℹ️ ADMIN_EMAIL or ADMIN_PASSWORD not set. Skipping admin user creation.")


### PR DESCRIPTION
## Summary
- Seed admin user from `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables, skipping when unset
- Document admin credential configuration in README
- Add `.env.example` with the new environment variables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a61528d4248333a124c80b44323da7