### PR TITLE
Add Docker ignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Exclude unnecessary files from Docker build context
+*.db
+*.sqlite3
+*.xlsx
+dist/
+build/
+.venv/
+tests/
+__pycache__/
+*.pyc
+.git
+.gitignore
+.env
+*.log


### PR DESCRIPTION
## Summary
- add a `.dockerignore` to exclude databases, spreadsheets, build artifacts, virtual environments, tests, and other local-only files from Docker build context

## Testing
- `docker build .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_b_68a6380778988333a2843acc9f4f4779