### PR TITLE
Use file-based templates for auth blueprint

### DIFF
--- a/services/auth.py
+++ b/services/auth.py
@@ -6,15 +6,13 @@ from __future__ import annotations
 
 from flask import (
     Blueprint,
-    render_template_string,
+    render_template,
     request,
     redirect,
     url_for,
     session,
     flash,
-    current_app,
 )
-from jinja2 import DictLoader
 
 from db import Session, User
 from services.auth_utils import (
@@ -36,114 +34,11 @@ def remove_session(exception=None):
     if hasattr(Session, "remove"):
         Session.remove()
 
-# ---- Inline templates ----
-BASE = """
-<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ title or 'Auth' }}</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
-    <style>
-      body, .container { background:#a0a0a0; color:#fff; }
-      .btn { background:#005B99; color:#fff; border-radius:6px; font-weight:600; }
-      .btn:hover { background:#003366; }
-      table th, table td { color:#fff; }
-    </style>
-  </head>
-  <body>
-    <main class="container">
-      {% with messages = get_flashed_messages(with_categories=true) %}
-        {% if messages %}
-          {% for cat, msg in messages %}
-            <article class="{{ 'secondary' if cat=='info' else '' }}">{{ msg }}</article>
-          {% endfor %}
-        {% endif %}
-      {% endwith %}
-      {% block content %}{% endblock %}
-    </main>
-  </body>
-</html>
-"""
-
-AUTH = """
-{% extends 'base.html' %}
-{% block content %}
-  <h2>Authentication</h2>
-  <div class="grid">
-    <article>
-      <h3>Login</h3>
-      <form method="post" action="{{ url_for('auth_bp.login') }}">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        <label>Email <input type="email" name="email" required></label>
-        <label>Password <input type="password" name="password" required></label>
-        <button class="btn" type="submit">Login</button>
-      </form>
-    </article>
-    <article>
-      <h3>Register</h3>
-      <form method="post" action="{{ url_for('auth_bp.register') }}">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-        <label>Name <input name="name" required></label>
-        <label>Email <input type="email" name="email" required></label>
-        <label>Phone <input name="phone"></label>
-        <label>Business Name <input name="business_name"></label>
-        <label>Business Phone <input name="business_phone"></label>
-        <label>Password <input type="password" name="password" required></label>
-        <small>Min 14 chars w/ upper, lower, number, symbol; or 24+ letters only.</small>
-        <button class="btn" type="submit">Create Account</button>
-      </form>
-    </article>
-  </div>
-{% endblock %}
-"""
-
-USERS = """
-{% extends 'base.html' %}
-{% block content %}
-  <h2>Manage Users</h2>
-  <table>
-    <thead>
-      <tr><th>Name</th><th>Email</th><th>Role</th><th>Approved</th><th>Actions</th></tr>
-    </thead>
-    <tbody>
-      {% for u in users %}
-        <tr>
-          <td>{{ u.name }}</td>
-          <td>{{ u.email }}</td>
-          <td>{{ u.role }}</td>
-          <td>{{ 'Yes' if u.is_approved else 'No' }}</td>
-          <td>
-            {% if not u.is_approved %}
-              <form method="post" action="{{ url_for('auth_bp.approve_user') }}" style="display:inline;">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
-                <input type="hidden" name="email" value="{{ u.email }}" />
-                <button class="btn" type="submit">Approve</button>
-              </form>
-            {% endif %}
-          </td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-{% endblock %}
-"""
-
-from flask import current_app
-
-def _ensure_templates():
-    if not isinstance(current_app.jinja_loader, DictLoader):
-        current_app.jinja_loader = DictLoader({})
-    current_app.jinja_loader.mapping.setdefault('base.html', BASE)
-    current_app.jinja_loader.mapping.setdefault('auth.html', AUTH)
-    current_app.jinja_loader.mapping.setdefault('users.html', USERS)
-
 # ---- Routes ----
 
 @auth_bp.route('/auth', methods=['GET'])
 def auth_page():
-    _ensure_templates()
-    return render_template_string(AUTH, title='Auth')
+    return render_template('auth/auth.html', title='Auth')
 
 @auth_bp.route('/login', methods=['POST'])
 def login():
@@ -201,9 +96,8 @@ def _require_admin():
 def users_page():
     if not _require_admin():
         return redirect(url_for('auth_bp.auth_page'))
-    _ensure_templates()
     users = list_users()
-    return render_template_string(USERS, users=users, title='Users')
+    return render_template('auth/users.html', users=users, title='Users')
 
 @auth_bp.route('/admin/users/approve', methods=['POST'])
 def approve_user():

--- a/templates/auth/auth.html
+++ b/templates/auth/auth.html
@@ -1,0 +1,29 @@
+{% extends 'auth/base.html' %}
+{% block content %}
+  <h2>Authentication</h2>
+  <div class="grid">
+    <article>
+      <h3>Login</h3>
+      <form method="post" action="{{ url_for('auth_bp.login') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <label>Email <input type="email" name="email" required></label>
+        <label>Password <input type="password" name="password" required></label>
+        <button class="btn" type="submit">Login</button>
+      </form>
+    </article>
+    <article>
+      <h3>Register</h3>
+      <form method="post" action="{{ url_for('auth_bp.register') }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <label>Name <input name="name" required></label>
+        <label>Email <input type="email" name="email" required></label>
+        <label>Phone <input name="phone"></label>
+        <label>Business Name <input name="business_name"></label>
+        <label>Business Phone <input name="business_phone"></label>
+        <label>Password <input type="password" name="password" required></label>
+        <small>Min 14 chars w/ upper, lower, number, symbol; or 24+ letters only.</small>
+        <button class="btn" type="submit">Create Account</button>
+      </form>
+    </article>
+  </div>
+{% endblock %}

--- a/templates/auth/base.html
+++ b/templates/auth/base.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ title or 'Auth' }}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+    <style>
+      body, .container { background:#a0a0a0; color:#fff; }
+      .btn { background:#005B99; color:#fff; border-radius:6px; font-weight:600; }
+      .btn:hover { background:#003366; }
+      table th, table td { color:#fff; }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          {% for cat, msg in messages %}
+            <article class="{{ 'secondary' if cat=='info' else '' }}">{{ msg }}</article>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>

--- a/templates/auth/users.html
+++ b/templates/auth/users.html
@@ -1,0 +1,28 @@
+{% extends 'auth/base.html' %}
+{% block content %}
+  <h2>Manage Users</h2>
+  <table>
+    <thead>
+      <tr><th>Name</th><th>Email</th><th>Role</th><th>Approved</th><th>Actions</th></tr>
+    </thead>
+    <tbody>
+      {% for u in users %}
+        <tr>
+          <td>{{ u.name }}</td>
+          <td>{{ u.email }}</td>
+          <td>{{ u.role }}</td>
+          <td>{{ 'Yes' if u.is_approved else 'No' }}</td>
+          <td>
+            {% if not u.is_approved %}
+              <form method="post" action="{{ url_for('auth_bp.approve_user') }}" style="display:inline;">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+                <input type="hidden" name="email" value="{{ u.email }}" />
+                <button class="btn" type="submit">Approve</button>
+              </form>
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Move inline auth templates to dedicated files under `templates/auth`
- Swap `render_template_string` for `render_template` and remove DictLoader setup
- Serve auth and user management pages from the new templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68a656679c6883339f9be6820df48db4