### PR TITLE
Enable CSRF protection and secure reset form

### DIFF
--- a/config.py
+++ b/config.py
@@ -14,3 +14,4 @@ class Config:
     GOOGLE_MAPS_API_KEY = os.getenv("GOOGLE_MAPS_API_KEY", "")
     # Mail/reset settings (optional):
     MAIL_DEFAULT_SENDER = os.getenv("MAIL_DEFAULT_SENDER", "no-reply@example.com")
+    WTF_CSRF_ENABLED = True

--- a/templates/reset_request.html
+++ b/templates/reset_request.html
@@ -6,6 +6,7 @@
   {% endif %}
 {% endwith %}
 <form method="post">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
   <label>Email <input type="email" name="email"></label><br>
   <button type="submit">Send Reset Link</button>
 </form>


### PR DESCRIPTION
## Summary
- enable CSRF in application config
- secure password reset request form with CSRF token

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a6567560a48333b8c1479bb33d8dbf