### PR TITLE
Add devcontainer Dockerfile for Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /workspace
+
+# Install system dependencies for building Python packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,8 @@
 {
   "name": "quote_tool",
   "build": {
-    "dockerfile": "Dockerfile",
-    "context": ".."
+    "context": "..",
+    "dockerfile": "Dockerfile"
   },
   "forwardPorts": [8000],
   "postCreateCommand": "pip install --upgrade pip && pip install -r requirements.txt",


### PR DESCRIPTION
## Summary
- add Python 3.11-based Dockerfile for devcontainer
- ensure devcontainer.json references new Dockerfile

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a7544402f48333bf78dae783056a90